### PR TITLE
BSOD Bad_pool bug Changes 

### DIFF
--- a/sys/create.c
+++ b/sys/create.c
@@ -149,10 +149,11 @@ DokanGetFCB(
 		ExFreePool(FileName);
 	}
 
+	InterlockedIncrement(&fcb->FileCount);
+
 	ExReleaseResourceLite(&Vcb->Resource);
 	KeLeaveCriticalRegion();
 
-	InterlockedIncrement(&fcb->FileCount);
 	return fcb;
 }
 
@@ -173,7 +174,7 @@ DokanFreeFCB(
 	ExAcquireResourceExclusiveLite(&vcb->Resource, TRUE);
 	ExAcquireResourceExclusiveLite(&Fcb->Resource, TRUE);
 
-	Fcb->FileCount--;
+	InterlockedDecrement(&Fcb->FileCount)
 
 	if (Fcb->FileCount == 0) {
 


### PR DESCRIPTION

1) I used  0.6.0 for while and had BSOD very often.
2) Than i patched according to advices from based on advice from https://code.google.com/p/dokan/issues/detail?id=229 adn with this i had no BSOD for almost year.
3) Now after upgrade to this version 0.7.1(because this one have subscribed 64bit drivers ) I got BSOD today again. It typically happen if u use intensive parallel reading/writing.