### PR TITLE
Fix DbgPrint message for CreateDisposition

### DIFF
--- a/dokan/create.c
+++ b/dokan/create.c
@@ -116,7 +116,7 @@ DispatchCreate(
 	} else {
 		DWORD creationDisposition = OPEN_EXISTING;
 		fileInfo.IsDirectory = FALSE;
-		DbgPrint("   CreateDisposition %0x08X\n", disposition);
+		DbgPrint("   CreateDisposition 0x%08X\n", disposition);
 		switch(disposition) {
 			case FILE_CREATE:
 				creationDisposition = CREATE_NEW;


### PR DESCRIPTION
It was printing the number in hexadecimal, but appending 08X at the end.
Fixed to add 0x at the beginning, which probably was the intended
output.