### PR TITLE
Fix DokanUnmount bug

### DIFF
--- a/dokan/mount.c
+++ b/dokan/mount.c
@@ -237,7 +237,7 @@ BOOL DOKANAPI
 DokanUnmount(
 	WCHAR	DriveLetter)
 {
-	WCHAR mountPoint[] = L"M:\\";
+	WCHAR mountPoint[] = L"M:";
 	mountPoint[0] = DriveLetter;
 	return DokanRemoveMountPoint(mountPoint);
 }

--- a/dokan/readme.txt
+++ b/dokan/readme.txt
@@ -313,10 +313,11 @@ otherwise, the following error code is returned.
 Unmounting
 ==========
 
-File system can be unmounted by calling the function DokanUnmount.  In
-most cases when the programs or shells use the file system hang,
-unmount operation will solve the problems by bringing the system to
-the previous state when the file system is not mounted.
+File system can be unmounted by calling the function DokanUnmount or
+DokanRemoveMountPoint.  In most cases when the programs or shells use
+the file system hang, unmount operation will solve the problems by
+bringing the system to the previous state when the file system is not
+mounted.
 
 User may use DokanCtl to unmount file system like this:
    > dokanctl.exe /u DriveLetter


### PR DESCRIPTION
As reported in the mailing list, DokanUnmount called
DokanRemoveMountPoint with an extra character at the end. Fixed it, and
mention DokanRemoveMountPoint in the readme.txt, since is an exported
function in the public header and is necessary if you mount the file
system in a path, not a drive letter.